### PR TITLE
Fix NuGet publish workflow output path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       run: dotnet build src/XperienceCommunity.Sustainability.csproj --configuration Release --no-restore
 
     - name: Pack
-      run: dotnet pack src/XperienceCommunity.Sustainability.csproj --configuration Release --no-build --output ./nupkg
+      run: dotnet pack src/XperienceCommunity.Sustainability.csproj --configuration Release --no-build
 
     - name: Publish to NuGet using Trusted Publishing
-      run: dotnet nuget push ./nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push src/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
Fixes the publish workflow to use the default dotnet pack output location (src/bin/Release/*.nupkg) instead of a custom ./nupkg directory that wasn't being created properly.