### PR TITLE
Remove --no-build flag from pack step in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       run: dotnet build src/XperienceCommunity.Sustainability.csproj --configuration Release --no-restore
 
     - name: Pack
-      run: dotnet pack src/XperienceCommunity.Sustainability.csproj --configuration Release --output ./nupkg
+      run: dotnet pack src/XperienceCommunity.Sustainability.csproj --configuration Release --no-build --output nupkg
 
     - name: Publish to NuGet using Trusted Publishing
       run: dotnet nuget push ./nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
The --no-build flag was causing issues with finding the build artifacts. Removing it allows dotnet pack to handle the build process properly and ensures the nupkg file is created in the correct output directory.