### PR TITLE
Fix NuGet publish workflow wildcard pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -30,6 +30,4 @@ jobs:
       run: dotnet pack src/XperienceCommunity.Sustainability.csproj --configuration Release --no-build --output nupkg
 
     - name: Publish to NuGet using Trusted Publishing
-      run: |
-        cd nupkg
-        dotnet nuget push *.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
Fixes the publish workflow by changing directory into nupkg before using wildcard pattern. PowerShell in GitHub Actions doesn't expand wildcards like ./nupkg/*.nupkg properly, but works when you cd into the directory first and use *.nupkg directly.