### PR TITLE
Add NuGet Trusted Publishing with OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,5 +29,11 @@ jobs:
     - name: Pack
       run: dotnet pack src/XperienceCommunity.Sustainability.csproj --configuration Release --no-build --output nupkg
 
+    - name: NuGet login (OIDC)
+      uses: NuGet/login@v1
+      id: nuget_login
+      with:
+        user: liamgold
+
     - name: Publish to NuGet using Trusted Publishing
-      run: dotnet nuget push nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push nupkg/*.nupkg --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
Fixes NuGet publishing by using the NuGet/login@v1 action to exchange GitHub OIDC token for a temporary NuGet API key. This is the proper way to use Trusted Publishing - no stored secrets needed!

Changes:
- Added NuGet/login@v1 step to authenticate via OIDC
- Pass the temporary API key to dotnet nuget push
- Keeps ubuntu-latest runner for reliability

Closes #19