### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  # Maintain dependencies for Admin Client project (npm)
+  - package-ecosystem: "npm"
+    directory: "/src/Client/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "07:00"
+    ignore:
+      - dependency-name: "@kentico/*"
+    groups:
+      react:
+        patterns:
+          - "react*"
+          - "@types/react*"
+      webpack:
+        patterns:
+          - "webpack*"
+          - "*-loader"
+    open-pull-requests-limit: 5
+
+  # Maintain NuGet dependencies for main library
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "07:00"
+    ignore:
+      - dependency-name: "Kentico.Xperience.*"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Adds Dependabot configuration to automate dependency updates
- Configures weekly checks on Tuesdays at 07:00
- NPM updates for Admin Client (`/src/Client/`) with grouped React and Webpack dependencies
- NuGet updates for main library with centralized package management
- Ignores Kentico packages to maintain manual control over framework updates

## Test plan
- [ ] Verify `.github/dependabot.yml` is properly formatted
- [ ] Wait for Dependabot to run and create PRs (if updates are available)
- [ ] Confirm Kentico packages are not updated automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)