### PR TITLE
Add explicit permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds explicit `permissions: contents: read` to CI workflow
- Follows security best practices and principle of least privilege
- Resolves CodeQL recommendation about missing workflow permissions
- CI workflow only needs read access to checkout and build code

## Test plan
- [ ] Verify CI workflow runs successfully on this PR
- [ ] Confirm no permission errors occur during build

🤖 Generated with [Claude Code](https://claude.com/claude-code)